### PR TITLE
TarArchiveEntry with only filename size 0 fix

### DIFF
--- a/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-api/src/test/java/org/carlspring/strongbox/artifact/generator/ArtifactGenerator.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.apache.commons.io.IOUtils;
 import org.springframework.core.io.ClassPathResource;
@@ -53,4 +54,19 @@ public interface ArtifactGenerator
         IOUtils.copy(resource.getInputStream(), os);
     }
 
+    /**
+     * Added this to handle instantiation of TarArchiveEntry with only file name.
+     * When TarArchiveEntry is created with only file name it considers it's size as zero, so size has to be set explicitly.
+     * @param licenseConfiguration
+     * @return size of the license file in bytes
+     * @throws IOException
+     */
+    default long getLicenseFileSize(LicenseConfiguration licenseConfiguration)
+            throws IOException
+    {
+        ClassPathResource resource = new ClassPathResource(licenseConfiguration.license().getLicenseFileSourcePath(),
+                                                           this.getClass().getClassLoader());
+
+        return Paths.get(resource.getURI()).toFile().length();
+    }
 }

--- a/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
+++ b/strongbox-storage/strongbox-storage-layout-providers/strongbox-storage-npm-layout-provider/src/test/java/org/carlspring/strongbox/artifact/generator/NpmArtifactGenerator.java
@@ -125,6 +125,7 @@ public class NpmArtifactGenerator
             for (LicenseConfiguration licenseConfiguration : licenses)
             {
                 TarArchiveEntry tarEntry = new TarArchiveEntry(licenseConfiguration.destinationPath());
+                tarEntry.setSize(getLicenseFileSize(licenseConfiguration));
                 tarOut.putArchiveEntry(tarEntry);
 
                 copyLicenseFile(licenseConfiguration, tarOut);


### PR DESCRIPTION
# Pull Request Description

This pull request closes #

# Acceptance Test

* [ ] Building the code with `mvn clean install -Dintegration.tests` still works.
* [ ] Running `mvn spring-boot:run` in the `strongbox-web-core` still starts up the application correctly.
* [ ] Building the code and running the `strongbox-distribution` from a `zip` or `tar.gz` still works.
* [ ] The tests in the [`strongbox-web-integration-tests`](https://github.com/strongbox/strongbox-web-integration-tests/) still run properly.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see strongbox/strongbox-docs#{PR_NUMBER}
  * [x] No
